### PR TITLE
Adding node-level config param support and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,25 @@ tree:
               cpu/energy: 0.019249600000000002
               memory/energy: 0.03057466958938112
 ```
+
+Executing the following command from the project root:
+
+```sh
+npm install
+
+npm run build
+
+npm link
+```
+
+Navigate to the folder with your manifest file and run the following:
+```sh
+npm link climatiq-impactframework-plugin
+```
+
+Go back to the root folder and run your manifest:
+```sh
+ie --manifest ./examples/vm-instance.yml --output ./examples/vm-instance-computed
+```
+
+The results will be saved to a new `yaml` file in `./examples`.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -57,6 +57,21 @@ describe('ClimatiqCalculator', () => {
       expect(result[0]).toHaveProperty('carbon');
     });
 
+    it('overrides global-config endpoint with node-level config endpoint.', async () => {
+      process.env.CLIMATIQ_API_KEY = 'xxx';
+      mockedAxios.post.mockResolvedValue({
+        data: mockVMInstanceResponseData,
+      });
+      const climatiq = ClimatiqCalculator(mockGlobalConfigForStorage);
+      expect(climatiq.metadata.kind).toEqual('execute');
+      const inputs = [mockVMInstanceParams.ValidParam];
+      const config: Record<string, any> = {endpoint: 'vm-instance'};
+      const result = await climatiq.execute(inputs, config);
+      expect(result.length).toStrictEqual(inputs.length);
+      expect(result[0]).toHaveProperty('energy');
+      expect(result[0]).toHaveProperty('carbon');
+    });
+
     it('returns enriched results from valid vm-instance inputs.', async () => {
       process.env.CLIMATIQ_API_KEY = 'xxx';
       mockedAxios.post.mockResolvedValue({

--- a/src/__tests__/validator.tests.ts
+++ b/src/__tests__/validator.tests.ts
@@ -7,8 +7,19 @@ import {
   mockMemoryParams,
   mockStorageParams,
 } from '../__mocks__';
+import {Endpoint} from '../types';
 
 describe('Validator', () => {
+  describe('validate', () => {
+    it('returns false when no endpoint set and no valid params found', () => {
+      const params: PluginParams[] = [{test: 'value'}];
+      const validator = Validator();
+      const validationResult = validator.validate(params, Endpoint.None);
+      expect(validationResult.valid).toEqual(false);
+      expect(validationResult.endpoint).toEqual(Endpoint.None);
+    });
+  });
+
   describe('isValidVMRequest', () => {
     it('returns true with a valid set of parameters', () => {
       const params: PluginParams[] = [mockVMInstanceParams.ValidParam];

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,21 @@ export const ClimatiqCalculator = (
     kind: 'execute',
   };
 
-  const execute = async (inputs: PluginParams[]): Promise<PluginParams[]> => {
+  const execute = async (
+    inputs: PluginParams[],
+    config: any
+  ): Promise<PluginParams[]> => {
     dotenv.config();
     if (!process.env.CLIMATIQ_API_KEY) {
       throw new Error('Climatiq API key missing from env variables');
     }
 
-    switch (globalConfig['endpoint']) {
+    const localConfig = {
+      ...globalConfig,
+      ...(config && config['endpoint'] ? {endpoint: config['endpoint']} : {}),
+    };
+
+    switch (localConfig['endpoint']) {
       case 'vm-instance':
         endpoint = Endpoint.VMInstance;
         break;
@@ -52,7 +60,7 @@ export const ClimatiqCalculator = (
 
     if (inputs.length > 0 && validationResult.valid) {
       console.log('Converting inputs');
-      const converter = Converter(globalConfig);
+      const converter = Converter(localConfig);
       const requestBatch: RequestBody[] = converter.toRequestBatch(
         inputs,
         endpoint


### PR DESCRIPTION
- Added support for node config param in execute()
- Added installation/run instructions to readme.md
- Added validator.validate test for an empty endpoint